### PR TITLE
Spectrogram -> SGram

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ private void GotNewBuffer(double[] audio)
 Then set up a timer to trigger rendering:
 ```cs
 private void timer1_Tick(object sender, EventArgs e){
-    Bitmap bmp = sg.GetBitmap(intensity: .4);
-    pictureBox1.Image?.Dispose();
-    pictureBox1.Image = bmp;
+    Bitmap oldBitmap = pictureBox1.Image;
+    pictureBox1.Image = sg.GetBitmap(intensity: .4);
+    oldBitmap?.Dispose();
 }
 ```
 

--- a/src/Spectrogram.MicrophoneDemo/FormMicrophone.cs
+++ b/src/Spectrogram.MicrophoneDemo/FormMicrophone.cs
@@ -48,7 +48,7 @@ namespace Spectrogram.MicrophoneDemo
         private void cbDevice_SelectedIndexChanged(object sender, EventArgs e) => StartListening();
         private void cbFftSize_SelectedIndexChanged(object sender, EventArgs e) => StartListening();
 
-        private Spectrogram spec;
+        private SGram spec;
         private Listener listener;
         private void StartListening()
         {
@@ -60,7 +60,7 @@ namespace Spectrogram.MicrophoneDemo
             pbSpectrogram.Image = null;
             listener?.Dispose();
             listener = new Listener(cbDevice.SelectedIndex, sampleRate);
-            spec = new Spectrogram(sampleRate, fftSize, stepSize);
+            spec = new SGram(sampleRate, fftSize, stepSize);
             //spec.SetWindow(FftSharp.Window.Rectangular(fftSize));
             pbSpectrogram.Height = spec.Height;
 

--- a/src/Spectrogram.Tests/ColormapExamples.cs
+++ b/src/Spectrogram.Tests/ColormapExamples.cs
@@ -17,7 +17,7 @@ namespace Spectrogram.Tests
         {
             (int sampleRate, double[] audio) = WavFile.ReadMono("../../../../../data/cant-do-that-44100.wav");
             int fftSize = 1 << 12;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 700, maxFreq: 2000);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 700, maxFreq: 2000);
             spec.SetWindow(FftSharp.Window.Hanning(fftSize / 3)); // sharper window than typical
             spec.Add(audio);
 

--- a/src/Spectrogram.Tests/FileFormat.cs
+++ b/src/Spectrogram.Tests/FileFormat.cs
@@ -13,7 +13,7 @@ namespace Spectrogram.Tests
         {
             (int sampleRate, double[] audio) = WavFile.ReadMono("../../../../../data/cant-do-that-44100.wav");
             int fftSize = 1 << 12;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 700, maxFreq: 2000);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 700, maxFreq: 2000);
             spec.SetWindow(FftSharp.Window.Hanning(fftSize / 3)); // sharper window than typical
             spec.Add(audio);
             spec.SaveData("../../../../../dev/sff/hal.sff");
@@ -33,7 +33,7 @@ namespace Spectrogram.Tests
         {
             (int sampleRate, double[] audio) = WavFile.ReadMono("../../../../../data/cant-do-that-44100.wav");
             int fftSize = 1 << 12;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 700);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 700);
             spec.SetWindow(FftSharp.Window.Hanning(fftSize / 3)); // sharper window than typical
             spec.Add(audio);
 
@@ -62,7 +62,7 @@ namespace Spectrogram.Tests
 
             // save the SFF
             int fftSize = 1 << 12;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 300, maxFreq: 2000);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 300, maxFreq: 2000);
             spec.Add(audio);
             spec.SaveData("testDoor.sff");
 
@@ -87,7 +87,7 @@ namespace Spectrogram.Tests
             Assert.AreEqual(48000, sampleRate);
 
             int fftSize = 1 << 12;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 300, maxFreq: 7999);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 300, maxFreq: 7999);
             spec.Add(audio);
             spec.SaveData("testDoorBig.sff");
         }

--- a/src/Spectrogram.Tests/Mel.cs
+++ b/src/Spectrogram.Tests/Mel.cs
@@ -14,7 +14,7 @@ namespace Spectrogram.Tests
         {
             (int sampleRate, double[] audio) = WavFile.ReadMono("../../../../../data/cant-do-that-44100.wav");
             int fftSize = 4096;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 500);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 500);
             spec.Add(audio);
             spec.SaveImage("halNotMel.png", 4, true);
             
@@ -88,7 +88,7 @@ namespace Spectrogram.Tests
         {
             (int sampleRate, double[] audio) = WavFile.ReadMono("../../../../../data/cant-do-that-44100.wav");
             int fftSize = 4096;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 500);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 500);
             //spec.Add(audio);
             Assert.Throws<InvalidOperationException>(() => { spec.SaveImage("empty.png"); });
         }

--- a/src/Spectrogram.Tests/Quickstart.cs
+++ b/src/Spectrogram.Tests/Quickstart.cs
@@ -12,7 +12,7 @@ namespace Spectrogram.Tests
         {
             (int sampleRate, double[] audio) = WavFile.ReadMono("../../../../../data/cant-do-that-44100.wav");
             int fftSize = 4096;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 500, maxFreq: 3000);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 500, maxFreq: 3000);
             spec.Add(audio);
             spec.SaveImage("../../../../../dev/graphics/hal.png", intensity: .2);
             
@@ -29,7 +29,7 @@ namespace Spectrogram.Tests
             int targetWidthPx = 3000;
             int stepSize = audio.Length / targetWidthPx;
 
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize, maxFreq: 2200);
+            var spec = new SGram(sampleRate, fftSize, stepSize, maxFreq: 2200);
             spec.Add(audio);
             spec.SaveImage("../../../../../dev/spectrogram-song.jpg", intensity: 5, dB: true);
 

--- a/src/Spectrogram.Tests/TestAGC.cs
+++ b/src/Spectrogram.Tests/TestAGC.cs
@@ -15,7 +15,7 @@ namespace Spectrogram.Tests
             (int sampleRate, double[] L) = WavFile.ReadMono(wavFilePath);
 
             int fftSize = 8192;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 2000, maxFreq: 3000);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 2000, maxFreq: 3000);
             spec.Add(L);
             spec.SaveImage("qrss-agc-off.png", intensity: 3);
         }
@@ -29,7 +29,7 @@ namespace Spectrogram.Tests
             (int sampleRate, double[] L) = WavFile.ReadMono(wavFilePath);
 
             int fftSize = 8192;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 2000, maxFreq: 3000);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 2000, maxFreq: 3000);
             spec.Add(L);
 
             var ffts = spec.GetFFTs();
@@ -64,7 +64,7 @@ namespace Spectrogram.Tests
             (int sampleRate, double[] L) = WavFile.ReadMono(wavFilePath);
 
             int fftSize = 8192;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 2000, maxFreq: 3000);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 2000, maxFreq: 3000);
             spec.Add(L);
 
             var ffts = spec.GetFFTs();

--- a/src/Spectrogram.Tests/WavUsingLibrary.cs
+++ b/src/Spectrogram.Tests/WavUsingLibrary.cs
@@ -35,7 +35,7 @@ namespace Spectrogram.Tests
 
             // CREATE THE SPECTROGRAM
             int fftSize = 8192;
-            var spec = new Spectrogram(sampleRate, fftSize, stepSize: 4_000, maxFreq: 2_000);
+            var spec = new SGram(sampleRate, fftSize, stepSize: 4_000, maxFreq: 2_000);
             spec.Add(audio);
             spec.SaveImage("asehgal.png", intensity: 10_000, dB: true);
         }

--- a/src/Spectrogram/Obsolete.cs
+++ b/src/Spectrogram/Obsolete.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Spectrogram
+{
+    [Obsolete("The Spectrogram class has been renamed to SGram")]
+    public class Spectrogram : SGram
+    {
+        public Spectrogram
+            (int sampleRate, int fftSize, int stepSize, double minFreq = 0, double maxFreq = double.PositiveInfinity, int? fixedWidth = null, int offsetHz = 0) :
+            base(sampleRate, fftSize, stepSize, minFreq, maxFreq, fixedWidth, offsetHz)
+        { }
+    }
+}

--- a/src/Spectrogram/SFF.cs
+++ b/src/Spectrogram/SFF.cs
@@ -60,7 +60,7 @@ namespace Spectrogram
             CalculateFrequencies();
         }
 
-        public SFF(Spectrogram spec, int melBinCount = 0)
+        public SFF(SGram spec, int melBinCount = 0)
         {
             SampleRate = spec.SampleRate;
             StepSize = spec.StepSize;

--- a/src/Spectrogram/SGram.cs
+++ b/src/Spectrogram/SGram.cs
@@ -3,14 +3,15 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Spectrogram
 {
-    public class Spectrogram
+    /// <summary>
+    /// Spectrogram generator.
+    /// Instantiate with FFT settings, use Add() methods to add signal data, then GetBitmap() or GetFfts()
+    /// </summary>
+    public class SGram
     {
         public int Width { get { return ffts.Count; } }
         public int Height { get { return settings.Height; } }
@@ -31,7 +32,7 @@ namespace Spectrogram
         private readonly List<double> newAudio = new List<double>();
         private Colormap cmap = Colormap.Viridis;
 
-        public Spectrogram(int sampleRate, int fftSize, int stepSize,
+        public SGram(int sampleRate, int fftSize, int stepSize,
             double minFreq = 0, double maxFreq = double.PositiveInfinity,
             int? fixedWidth = null, int offsetHz = 0)
         {
@@ -136,7 +137,7 @@ namespace Spectrogram
                 throw new InvalidOperationException("cannot get Mel spectrogram unless minimum frequency is 0Hz");
 
             var fftsMel = new List<double[]>();
-            foreach(var fft in ffts)
+            foreach (var fft in ffts)
                 fftsMel.Add(FftSharp.Transform.MelScale(fft, SampleRate, melBinCount));
 
             return fftsMel;

--- a/src/Spectrogram/Spectrogram.csproj
+++ b/src/Spectrogram/Spectrogram.csproj
@@ -20,7 +20,7 @@ Releases: https://github.com/swharden/Spectrogram/releases</PackageReleaseNotes>
 
   <ItemGroup>
     <PackageReference Include="FftSharp" Version="1.0.8" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'" />
     <None Include="icon.png">
       <Pack>True</Pack>


### PR DESCRIPTION
this PR renames Spectrogram to SGram to avoid a namespace collision as discussed in #30 