### PR TITLE
Memory Usage Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _"I'm sorry Dave... I'm afraid I can't do that"_
 * Source code for the WAV reading method is at the bottom of this page.
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(List<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 500, maxFreq: 3000);
 sg.Add(audio);
 sg.SaveImage("hal.png");
@@ -81,7 +81,7 @@ Review the source code of the demo application for additional details and consid
 This example demonstrates how to convert a MP3 file to a spectrogram image. A sample MP3 audio file in the [data folder](data) contains the audio track from Ken Barker's excellent piano performance of George Frideric Handel's Suite No. 5 in E major for harpsichord ([_The Harmonious Blacksmith_](https://en.wikipedia.org/wiki/The_Harmonious_Blacksmith)). This audio file is included [with permission](dev/Handel%20-%20Air%20and%20Variations.txt), and the [original video can be viewed on YouTube](https://www.youtube.com/watch?v=Mza-xqk770k).
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) = ReadWAV("song.wav");
+(List<double> audio, int sampleRate) = ReadWAV("song.wav");
 
 int fftSize = 16384;
 int targetWidthPx = 3000;
@@ -117,7 +117,7 @@ Spectrogram (2993, 817)
 These examples demonstrate the identical spectrogram analyzed with a variety of different colormaps. Spectrogram colormaps can be changed by calling the `SetColormap()` method:
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(List<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 8192, stepSize: 200, maxFreq: 3000);
 sg.Add(audio);
 sg.SetColormap(Colormap.Jet);
@@ -141,7 +141,7 @@ Cropped Linear Scale (0-3kHz) | Mel Scale (0-22 kHz)
 Amplitude perception in humans, like frequency perception, is logarithmic. Therefore, Mel spectrograms typically display log-transformed spectral power and are presented using Decibel units.
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(List<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 500, maxFreq: 3000);
 sg.Add(audio);
 
@@ -166,7 +166,7 @@ SFF files be saved using `Complex` data format (with real and imaginary values f
 This example creates a spectrogram but saves it using the SFF file format instead of saving it as an image. The SFF file can then be read in any language.
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(List<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 700, maxFreq: 2000);
 sg.Add(audio);
 sg.SaveData("hal.sff");
@@ -210,7 +210,7 @@ plt.show()
 You should customize your file-reading method to suit your specific application. I frequently use the NAudio package to read data from WAV and MP3 files. This function reads audio data from a mono WAV file and will be used for the examples on this page.
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) ReadWAV(string filePath, double multiplier = 16_000)
+(List<double> audio, int sampleRate) ReadWAV(string filePath, double multiplier = 16_000)
 {
     using var afr = new NAudio.Wave.AudioFileReader(filePath);
     int sampleRate = afr.WaveFormat.SampleRate;

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _"I'm sorry Dave... I'm afraid I can't do that"_
 * Source code for the WAV reading method is at the bottom of this page.
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(double[] audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 500, maxFreq: 3000);
 sg.Add(audio);
 sg.SaveImage("hal.png");
@@ -59,7 +59,7 @@ public Form1()
 
 Whenever an audio buffer gets filled, add the data to your Spectrogram:
 ```cs
-private void GotNewBuffer(IEnumerable<double> audio)
+private void GotNewBuffer(double[] audio)
 {
     sg.Add(audio);
 }
@@ -81,7 +81,7 @@ Review the source code of the demo application for additional details and consid
 This example demonstrates how to convert a MP3 file to a spectrogram image. A sample MP3 audio file in the [data folder](data) contains the audio track from Ken Barker's excellent piano performance of George Frideric Handel's Suite No. 5 in E major for harpsichord ([_The Harmonious Blacksmith_](https://en.wikipedia.org/wiki/The_Harmonious_Blacksmith)). This audio file is included [with permission](dev/Handel%20-%20Air%20and%20Variations.txt), and the [original video can be viewed on YouTube](https://www.youtube.com/watch?v=Mza-xqk770k).
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) = ReadWAV("song.wav");
+(double[] audio, int sampleRate) = ReadWAV("song.wav");
 
 int fftSize = 16384;
 int targetWidthPx = 3000;
@@ -117,7 +117,7 @@ Spectrogram (2993, 817)
 These examples demonstrate the identical spectrogram analyzed with a variety of different colormaps. Spectrogram colormaps can be changed by calling the `SetColormap()` method:
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(double[] audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 8192, stepSize: 200, maxFreq: 3000);
 sg.Add(audio);
 sg.SetColormap(Colormap.Jet);
@@ -141,7 +141,7 @@ Cropped Linear Scale (0-3kHz) | Mel Scale (0-22 kHz)
 Amplitude perception in humans, like frequency perception, is logarithmic. Therefore, Mel spectrograms typically display log-transformed spectral power and are presented using Decibel units.
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(double[] audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 500, maxFreq: 3000);
 sg.Add(audio);
 
@@ -166,7 +166,7 @@ SFF files be saved using `Complex` data format (with real and imaginary values f
 This example creates a spectrogram but saves it using the SFF file format instead of saving it as an image. The SFF file can then be read in any language.
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(double[] audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 700, maxFreq: 2000);
 sg.Add(audio);
 sg.SaveData("hal.sff");
@@ -210,17 +210,17 @@ plt.show()
 You should customize your file-reading method to suit your specific application. I frequently use the NAudio package to read data from WAV and MP3 files. This function reads audio data from a mono WAV file and will be used for the examples on this page.
 
 ```cs
-(IEnumerable<double> audio, int sampleRate) ReadWAV(string filePath, double multiplier = 16_000)
+(double[] audio, int sampleRate) ReadWAV(string filePath, double multiplier = 16_000)
 {
     using var afr = new NAudio.Wave.AudioFileReader(filePath);
     int sampleRate = afr.WaveFormat.SampleRate;
-    int sampleCount = (int)(afr.Length / afr.WaveFormat.BitsPerSample) * 8;
+    int sampleCount = (int)(afr.Length / afr.WaveFormat.BitsPerSample / 8);
     int channelCount = afr.WaveFormat.Channels;
     var audio = new List<double>(sampleCount);
     var buffer = new float[sampleRate * channelCount];
     int samplesRead = 0;
     while ((samplesRead = afr.Read(buffer, 0, buffer.Length)) > 0)
         audio.AddRange(buffer.Take(samplesRead).Select(x => x * multiplier));
-    return (audio, sampleRate);
+    return (audio.ToArray(), sampleRate);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _"I'm sorry Dave... I'm afraid I can't do that"_
 * Source code for the WAV reading method is at the bottom of this page.
 
 ```cs
-(List<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 500, maxFreq: 3000);
 sg.Add(audio);
 sg.SaveImage("hal.png");
@@ -81,7 +81,7 @@ Review the source code of the demo application for additional details and consid
 This example demonstrates how to convert a MP3 file to a spectrogram image. A sample MP3 audio file in the [data folder](data) contains the audio track from Ken Barker's excellent piano performance of George Frideric Handel's Suite No. 5 in E major for harpsichord ([_The Harmonious Blacksmith_](https://en.wikipedia.org/wiki/The_Harmonious_Blacksmith)). This audio file is included [with permission](dev/Handel%20-%20Air%20and%20Variations.txt), and the [original video can be viewed on YouTube](https://www.youtube.com/watch?v=Mza-xqk770k).
 
 ```cs
-(List<double> audio, int sampleRate) = ReadWAV("song.wav");
+(IEnumerable<double> audio, int sampleRate) = ReadWAV("song.wav");
 
 int fftSize = 16384;
 int targetWidthPx = 3000;
@@ -117,7 +117,7 @@ Spectrogram (2993, 817)
 These examples demonstrate the identical spectrogram analyzed with a variety of different colormaps. Spectrogram colormaps can be changed by calling the `SetColormap()` method:
 
 ```cs
-(List<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 8192, stepSize: 200, maxFreq: 3000);
 sg.Add(audio);
 sg.SetColormap(Colormap.Jet);
@@ -141,7 +141,7 @@ Cropped Linear Scale (0-3kHz) | Mel Scale (0-22 kHz)
 Amplitude perception in humans, like frequency perception, is logarithmic. Therefore, Mel spectrograms typically display log-transformed spectral power and are presented using Decibel units.
 
 ```cs
-(List<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 500, maxFreq: 3000);
 sg.Add(audio);
 
@@ -166,7 +166,7 @@ SFF files be saved using `Complex` data format (with real and imaginary values f
 This example creates a spectrogram but saves it using the SFF file format instead of saving it as an image. The SFF file can then be read in any language.
 
 ```cs
-(List<double> audio, int sampleRate) = ReadWAV("hal.wav");
+(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 700, maxFreq: 2000);
 sg.Add(audio);
 sg.SaveData("hal.sff");
@@ -210,7 +210,7 @@ plt.show()
 You should customize your file-reading method to suit your specific application. I frequently use the NAudio package to read data from WAV and MP3 files. This function reads audio data from a mono WAV file and will be used for the examples on this page.
 
 ```cs
-(List<double> audio, int sampleRate) ReadWAV(string filePath, double multiplier = 16_000)
+(IEnumerable<double> audio, int sampleRate) ReadWAV(string filePath, double multiplier = 16_000)
 {
     using var afr = new NAudio.Wave.AudioFileReader(filePath);
     int sampleRate = afr.WaveFormat.SampleRate;

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ _"I'm sorry Dave... I'm afraid I can't do that"_
 * Source code for the WAV reading method is at the bottom of this page.
 
 ```cs
-(double[] audio, int sampleRate) = ReadWAV("hal.wav");
+(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 500, maxFreq: 3000);
 sg.Add(audio);
 sg.SaveImage("hal.png");
@@ -59,7 +59,7 @@ public Form1()
 
 Whenever an audio buffer gets filled, add the data to your Spectrogram:
 ```cs
-private void GotNewBuffer(double[] audio)
+private void GotNewBuffer(IEnumerable<double> audio)
 {
     sg.Add(audio);
 }
@@ -81,7 +81,7 @@ Review the source code of the demo application for additional details and consid
 This example demonstrates how to convert a MP3 file to a spectrogram image. A sample MP3 audio file in the [data folder](data) contains the audio track from Ken Barker's excellent piano performance of George Frideric Handel's Suite No. 5 in E major for harpsichord ([_The Harmonious Blacksmith_](https://en.wikipedia.org/wiki/The_Harmonious_Blacksmith)). This audio file is included [with permission](dev/Handel%20-%20Air%20and%20Variations.txt), and the [original video can be viewed on YouTube](https://www.youtube.com/watch?v=Mza-xqk770k).
 
 ```cs
-(double[] audio, int sampleRate) = ReadWAV("song.wav");
+(IEnumerable<double> audio, int sampleRate) = ReadWAV("song.wav");
 
 int fftSize = 16384;
 int targetWidthPx = 3000;
@@ -117,7 +117,7 @@ Spectrogram (2993, 817)
 These examples demonstrate the identical spectrogram analyzed with a variety of different colormaps. Spectrogram colormaps can be changed by calling the `SetColormap()` method:
 
 ```cs
-(double[] audio, int sampleRate) = ReadWAV("hal.wav");
+(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 8192, stepSize: 200, maxFreq: 3000);
 sg.Add(audio);
 sg.SetColormap(Colormap.Jet);
@@ -141,7 +141,7 @@ Cropped Linear Scale (0-3kHz) | Mel Scale (0-22 kHz)
 Amplitude perception in humans, like frequency perception, is logarithmic. Therefore, Mel spectrograms typically display log-transformed spectral power and are presented using Decibel units.
 
 ```cs
-(double[] audio, int sampleRate) = ReadWAV("hal.wav");
+(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 500, maxFreq: 3000);
 sg.Add(audio);
 
@@ -166,7 +166,7 @@ SFF files be saved using `Complex` data format (with real and imaginary values f
 This example creates a spectrogram but saves it using the SFF file format instead of saving it as an image. The SFF file can then be read in any language.
 
 ```cs
-(double[] audio, int sampleRate) = ReadWAV("hal.wav");
+(IEnumerable<double> audio, int sampleRate) = ReadWAV("hal.wav");
 var sg = new SpectrogramGenerator(sampleRate, fftSize: 4096, stepSize: 700, maxFreq: 2000);
 sg.Add(audio);
 sg.SaveData("hal.sff");
@@ -210,7 +210,7 @@ plt.show()
 You should customize your file-reading method to suit your specific application. I frequently use the NAudio package to read data from WAV and MP3 files. This function reads audio data from a mono WAV file and will be used for the examples on this page.
 
 ```cs
-(double[] audio, int sampleRate) ReadWAV(string filePath, double multiplier = 16_000)
+(IEnumerable<double> audio, int sampleRate) ReadWAV(string filePath, double multiplier = 16_000)
 {
     using var afr = new NAudio.Wave.AudioFileReader(filePath);
     int sampleRate = afr.WaveFormat.SampleRate;
@@ -221,6 +221,6 @@ You should customize your file-reading method to suit your specific application.
     int samplesRead = 0;
     while ((samplesRead = afr.Read(buffer, 0, buffer.Length)) > 0)
         audio.AddRange(buffer.Take(samplesRead).Select(x => x * multiplier));
-    return (audio.ToArray(), sampleRate);
+    return (audio, sampleRate);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ You should customize your file-reading method to suit your specific application.
 {
     using var afr = new NAudio.Wave.AudioFileReader(filePath);
     int sampleRate = afr.WaveFormat.SampleRate;
-    int sampleCount = (int)(afr.Length / afr.WaveFormat.BitsPerSample / 8);
+    int bytesPerSample = afr.WaveFormat.BitsPerSample / 8;
+    int sampleCount = (int)(afr.Length / bytesPerSample);
     int channelCount = afr.WaveFormat.Channels;
     var audio = new List<double>(sampleCount);
     var buffer = new float[sampleRate * channelCount];

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ You should customize your file-reading method to suit your specific application.
 {
     using var afr = new NAudio.Wave.AudioFileReader(filePath);
     int sampleRate = afr.WaveFormat.SampleRate;
-    int sampleCount = (int)(afr.Length / afr.WaveFormat.BitsPerSample / 8);
+    int sampleCount = (int)(afr.Length / afr.WaveFormat.BitsPerSample) * 8;
     int channelCount = afr.WaveFormat.Channels;
     var audio = new List<double>(sampleCount);
     var buffer = new float[sampleRate * channelCount];

--- a/dev/python/readwav.py
+++ b/dev/python/readwav.py
@@ -1,0 +1,16 @@
+"""
+sample rate: 44100
+values: 166671
+value 12345: 4435
+"""
+from scipy.io import wavfile
+import pathlib
+PATH_HERE = pathlib.Path(__file__).parent
+PATH_DATA = PATH_HERE.joinpath("../../data")
+
+if __name__ == "__main__":
+    wavFilePath = PATH_DATA.joinpath("cant-do-that-44100.wav")
+    samplerate, data = wavfile.read(wavFilePath)
+    print(f"sample rate: {samplerate}")
+    print(f"values: {len(data)}")
+    print(f"value 12345: {data[12345]}")

--- a/dev/python/readwav.py
+++ b/dev/python/readwav.py
@@ -9,8 +9,7 @@ PATH_HERE = pathlib.Path(__file__).parent
 PATH_DATA = PATH_HERE.joinpath("../../data")
 
 if __name__ == "__main__":
-    wavFilePath = PATH_DATA.joinpath("cant-do-that-44100.wav")
-    samplerate, data = wavfile.read(wavFilePath)
-    print(f"sample rate: {samplerate}")
-    print(f"values: {len(data)}")
-    print(f"value 12345: {data[12345]}")
+    for wavFilePath in PATH_DATA.glob("*.wav"):
+        wavFilePath = PATH_DATA.joinpath(wavFilePath)
+        samplerate, data = wavfile.read(wavFilePath)
+        print(f"{wavFilePath.name}, {samplerate}, {len(data)}")

--- a/src/Spectrogram.Tests/AudioFile.cs
+++ b/src/Spectrogram.Tests/AudioFile.cs
@@ -7,11 +7,15 @@ namespace Spectrogram.Tests
 {
     public static class AudioFile
     {
+        /// <summary>
+        /// Use NAudio to read the contents of a WAV file.
+        /// </summary>
         public static (double[] audio, int sampleRate) ReadWAV(string filePath, double multiplier = 16_000)
         {
             using var afr = new NAudio.Wave.AudioFileReader(filePath);
             int sampleRate = afr.WaveFormat.SampleRate;
-            int sampleCount = (int)(afr.Length / afr.WaveFormat.BitsPerSample / 8);
+            int bytesPerSample = afr.WaveFormat.BitsPerSample / 8;
+            int sampleCount = (int)afr.Length / bytesPerSample;
             int channelCount = afr.WaveFormat.Channels;
             var audio = new List<double>(sampleCount);
             var buffer = new float[sampleRate * channelCount];
@@ -21,6 +25,9 @@ namespace Spectrogram.Tests
             return (audio.ToArray(), sampleRate);
         }
 
+        /// <summary>
+        /// Use MP3Sharp to read the contents of an MP3 file.
+        /// </summary>
         public static double[] ReadMP3(string filePath, int bufferSize = 4096)
         {
             List<double> audio = new List<double>();

--- a/src/Spectrogram.Tests/AudioFileTests.cs
+++ b/src/Spectrogram.Tests/AudioFileTests.cs
@@ -10,14 +10,18 @@ namespace Spectrogram.Tests
         /// <summary>
         /// Compare values read from the WAV reader against those read by Python's SciPy module (see script in /dev folder)
         /// </summary>
-        [Test]
-        public void Test_AudioFile_KnownValues()
+        [TestCase("cant-do-that-44100.wav", 44_100, 166_671, 1)]
+        [TestCase("03-02-03-01-02-01-19.wav", 48_000, 214_615, 1)]
+        [TestCase("qrss-10min.wav", 6_000, 3_600_000, 1)]
+        [TestCase("cant-do-that-11025-stereo.wav", 11_025, 41668, 2)]
+        [TestCase("asehgal-original.wav", 40_000, 1_600_000, 1)]
+        public void Test_AudioFile_LengthAndSampleRate(string filename, int knownRate, int knownLength, int channels)
         {
-            (double[] audio, int sampleRate) = AudioFile.ReadWAV("../../../../../data/cant-do-that-44100.wav", multiplier: 32_000);
+            string filePath = $"../../../../../data/{filename}";
+            (double[] audio, int sampleRate) = AudioFile.ReadWAV(filePath);
 
-            Assert.AreEqual(44100, sampleRate);
-            Assert.AreEqual(166671, audio.Length);
-            Assert.AreEqual(4435, audio[12345], 1000);
+            Assert.AreEqual(knownRate, sampleRate);
+            Assert.AreEqual(knownLength, audio.Length / channels);
         }
     }
 }

--- a/src/Spectrogram.Tests/AudioFileTests.cs
+++ b/src/Spectrogram.Tests/AudioFileTests.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Spectrogram.Tests
+{
+    class AudioFileTests
+    {
+        /// <summary>
+        /// Compare values read from the WAV reader against those read by Python's SciPy module (see script in /dev folder)
+        /// </summary>
+        [Test]
+        public void Test_AudioFile_KnownValues()
+        {
+            (double[] audio, int sampleRate) = AudioFile.ReadWAV("../../../../../data/cant-do-that-44100.wav", multiplier: 32_000);
+
+            Assert.AreEqual(44100, sampleRate);
+            Assert.AreEqual(166671, audio.Length);
+            Assert.AreEqual(4435, audio[12345], 1000);
+        }
+    }
+}

--- a/src/Spectrogram/SpectrogramGenerator.cs
+++ b/src/Spectrogram/SpectrogramGenerator.cs
@@ -9,18 +9,70 @@ namespace Spectrogram
 {
     public class SpectrogramGenerator
     {
+        /// <summary>
+        /// Number of pixel columns (FFT samples) in the spectrogram image
+        /// </summary>
         public int Width { get { return ffts.Count; } }
+
+        /// <summary>
+        /// Number of pixel rows (frequency bins) in the spectrogram image
+        /// </summary>
         public int Height { get { return settings.Height; } }
+
+        /// <summary>
+        /// Number of samples to use for each FFT (must be a power of 2)
+        /// </summary>
         public int FftSize { get { return settings.FftSize; } }
+
+        /// <summary>
+        /// Vertical resolution (frequency bin size depends on FftSize and SampleRate)
+        /// </summary>
         public double HzPerPx { get { return settings.HzPerPixel; } }
+
+        /// <summary>
+        /// Horizontal resolution (seconds per pixel depends on StepSize)
+        /// </summary>
         public double SecPerPx { get { return settings.StepLengthSec; } }
+
+        /// <summary>
+        /// Number of FFTs that remain to be processed for data which has been added but not yet analuyzed
+        /// </summary>
         public int FftsToProcess { get { return (newAudio.Count - settings.FftSize) / settings.StepSize; } }
+
+        /// <summary>
+        /// Total number of FFT steps processed
+        /// </summary>
         public int FftsProcessed { get; private set; }
+
+        /// <summary>
+        /// Index of the pixel column which will be populated next. Location of vertical line for wrap-around displays.
+        /// </summary>
         public int NextColumnIndex { get { return (FftsProcessed + rollOffset) % Width; } }
+
+        /// <summary>
+        /// This value is added to displayed frequency axis tick labels
+        /// </summary>
         public int OffsetHz { get { return settings.OffsetHz; } set { settings.OffsetHz = value; } }
+
+        /// <summary>
+        /// Number of samples per second
+        /// </summary>
         public int SampleRate { get { return settings.SampleRate; } }
+
+        /// <summary>
+        /// Number of samples to step forward after each FFT is processed.
+        /// This value controls the horizontal resolution of the spectrogram.
+        /// </summary>
         public int StepSize { get { return settings.StepSize; } }
+
+        /// <summary>
+        /// The spectrogram is trimmed to cut-off frequencies below this value.
+        /// </summary>
         public double FreqMax { get { return settings.FreqMax; } }
+
+        /// <summary>
+        /// The spectrogram is trimmed to cut-off frequencies above this value.
+        /// </summary>
         public double FreqMin { get { return settings.FreqMin; } }
 
         private readonly Settings settings;
@@ -28,9 +80,28 @@ namespace Spectrogram
         private readonly List<double> newAudio;
         private Colormap cmap = Colormap.Viridis;
 
-        public SpectrogramGenerator(int sampleRate, int fftSize, int stepSize,
-            double minFreq = 0, double maxFreq = double.PositiveInfinity,
-            int? fixedWidth = null, int offsetHz = 0, List<double> initialAudioList = null)
+        /// <summary>
+        /// Instantiate a spectrogram generator.
+        /// This module calculates the FFT over a moving window as data comes in.
+        /// Using the Add() method to load new data and process it as it arrives.
+        /// </summary>
+        /// <param name="sampleRate">Number of samples per second (Hz)</param>
+        /// <param name="fftSize">Number of samples to use for each FFT operation. This value must be a power of 2.</param>
+        /// <param name="stepSize">Number of samples to step forward</param>
+        /// <param name="minFreq">Frequency data lower than this value (Hz) will not be stored</param>
+        /// <param name="maxFreq">Frequency data higher than this value (Hz) will not be stored</param>
+        /// <param name="fixedWidth">Spectrogram output will always be sized to this width (column count)</param>
+        /// <param name="offsetHz">This value will be added to displayed frequency axis tick labels</param>
+        /// <param name="initialAudioList">Analyze this data immediately (alternative to calling Add() later)</param>
+        public SpectrogramGenerator(
+            int sampleRate,
+            int fftSize,
+            int stepSize,
+            double minFreq = 0,
+            double maxFreq = double.PositiveInfinity,
+            int? fixedWidth = null,
+            int offsetHz = 0,
+            List<double> initialAudioList = null)
         {
             settings = new Settings(sampleRate, fftSize, stepSize, minFreq, maxFreq, offsetHz);
 
@@ -58,11 +129,18 @@ namespace Spectrogram
                    $"overlap: {settings.StepOverlapFrac * 100:N0}%";
         }
 
+        /// <summary>
+        /// Set the colormap to use for future renders
+        /// </summary>
         public void SetColormap(Colormap cmap)
         {
             this.cmap = cmap ?? this.cmap;
         }
 
+        /// <summary>
+        /// Load a custom window kernel to multiply against each FFT sample prior to processing.
+        /// Windows must be at least the length of FftSize and typically have a sum of 1.0.
+        /// </summary>
         public void SetWindow(double[] newWindow)
         {
             if (newWindow.Length > settings.FftSize)
@@ -84,6 +162,9 @@ namespace Spectrogram
         [Obsolete("use the Add() method", true)]
         public void AddScroll(float[] values) { }
 
+        /// <summary>
+        /// Load new data into the spectrogram generator
+        /// </summary>
         public void Add(IEnumerable<double> audio, bool process = true)
         {
             newAudio.AddRange(audio);
@@ -91,12 +172,26 @@ namespace Spectrogram
                 Process();
         }
 
+        /// <summary>
+        /// The roll offset is used to calculate NextColumnIndex and can be set to a positive number 
+        /// to begin adding new columns to the center of the spectrogram.
+        /// This can also be used to artificially move the next column index to zero even though some
+        /// data has already been accumulated.
+        /// </summary>
         private int rollOffset = 0;
+
+        /// <summary>
+        /// Reset the next column index such that the next processed FFT will appear at the far left of the spectrogram.
+        /// </summary>
+        /// <param name="offset"></param>
         public void RollReset(int offset = 0)
         {
             rollOffset = -FftsProcessed + offset;
         }
 
+        /// <summary>
+        /// Perform FFT analysis on all unprocessed data
+        /// </summary>
         public double[][] Process()
         {
             if (FftsToProcess < 1)
@@ -129,6 +224,10 @@ namespace Spectrogram
             return newFfts;
         }
 
+        /// <summary>
+        /// Return a list of the mel-scaled FFTs contained in this spectrogram
+        /// </summary>
+        /// <param name="melBinCount">Total number of output bins to use. Choose a value significantly smaller than Height.</param>
         public List<double[]> GetMelFFTs(int melBinCount)
         {
             if (settings.FreqMin != 0)
@@ -141,15 +240,44 @@ namespace Spectrogram
             return fftsMel;
         }
 
+        /// <summary>
+        /// Create and return a spectrogram bitmap from the FFTs stored in memory.
+        /// </summary>
+        /// <param name="intensity">Multiply the output by a fixed value to change its brightness.</param>
+        /// <param name="dB">If true, output will be log-transformed.</param>
+        /// <param name="dBScale">If dB scaling is in use, this multiplier will be applied before log transformation.</param>
+        /// <param name="roll">Behavior of the spectrogram when it is full of data. 
+        /// Roll (true) adds new columns on the left overwriting the oldest ones.
+        /// Scroll (false) slides the whole image to the left and adds new columns to the right.</param>
         public Bitmap GetBitmap(double intensity = 1, bool dB = false, double dBScale = 1, bool roll = false) =>
             Image.GetBitmap(ffts, cmap, intensity, dB, dBScale, roll, NextColumnIndex);
 
+        /// <summary>
+        /// Create a Mel-scaled spectrogram.
+        /// </summary>
+        /// <param name="melBinCount">Total number of output bins to use. Choose a value significantly smaller than Height.</param>
+        /// <param name="intensity">Multiply the output by a fixed value to change its brightness.</param>
+        /// <param name="dB">If true, output will be log-transformed.</param>
+        /// <param name="dBScale">If dB scaling is in use, this multiplier will be applied before log transformation.</param>
+        /// <param name="roll">Behavior of the spectrogram when it is full of data. 
+        /// Roll (true) adds new columns on the left overwriting the oldest ones.
+        /// Scroll (false) slides the whole image to the left and adds new columns to the right.</param>
         public Bitmap GetBitmapMel(int melBinCount = 25, double intensity = 1, bool dB = false, double dBScale = 1, bool roll = false) =>
             Image.GetBitmap(GetMelFFTs(melBinCount), cmap, intensity, dB, dBScale, roll, NextColumnIndex);
 
         [Obsolete("use SaveImage()", true)]
         public void SaveBitmap(Bitmap bmp, string fileName) { }
 
+        /// <summary>
+        /// Generate the spectrogram and save it as an image file.
+        /// </summary>
+        /// <param name="fileName">Path of the file to save.</param>
+        /// <param name="intensity">Multiply the output by a fixed value to change its brightness.</param>
+        /// <param name="dB">If true, output will be log-transformed.</param>
+        /// <param name="dBScale">If dB scaling is in use, this multiplier will be applied before log transformation.</param>
+        /// <param name="roll">Behavior of the spectrogram when it is full of data. 
+        /// Roll (true) adds new columns on the left overwriting the oldest ones.
+        /// Scroll (false) slides the whole image to the left and adds new columns to the right.</param>
         public void SaveImage(string fileName, double intensity = 1, bool dB = false, double dBScale = 1, bool roll = false)
         {
             if (ffts.Count == 0)
@@ -172,6 +300,15 @@ namespace Spectrogram
             Image.GetBitmap(ffts, cmap, intensity, dB, dBScale, roll, NextColumnIndex).Save(fileName, fmt);
         }
 
+        /// <summary>
+        /// Create and return a spectrogram bitmap from the FFTs stored in memory.
+        /// The output will be scaled-down vertically by binning according to a reduction factor and keeping the brightest pixel value in each bin.
+        /// </summary>
+        /// <param name="intensity">Multiply the output by a fixed value to change its brightness.</param>
+        /// <param name="dB">If true, output will be log-transformed.</param>
+        /// <param name="dBScale">If dB scaling is in use, this multiplier will be applied before log transformation.</param>
+        /// <param name="roll">Behavior of the spectrogram when it is full of data. 
+        /// <param name="reduction"></param>
         public Bitmap GetBitmapMax(double intensity = 1, bool dB = false, double dBScale = 1, bool roll = false, int reduction = 4)
         {
             List<double[]> ffts2 = new List<double[]>();
@@ -187,6 +324,9 @@ namespace Spectrogram
             return Image.GetBitmap(ffts2, cmap, intensity, dB, dBScale, roll, NextColumnIndex);
         }
 
+        /// <summary>
+        /// Export spectrogram data using the Spectrogram File Format (SFF)
+        /// </summary>
         public void SaveData(string filePath, int melBinCount = 0)
         {
             if (!filePath.EndsWith(".sff", StringComparison.OrdinalIgnoreCase))
@@ -194,7 +334,15 @@ namespace Spectrogram
             new SFF(this, melBinCount).Save(filePath);
         }
 
+        /// <summary>
+        /// Defines the total number of FFTs (spectrogram columns) to store in memory. Determines Width.
+        /// </summary>
         private int fixedWidth = 0;
+
+        /// <summary>
+        /// Configure the Spectrogram to maintain a fixed number of pixel columns.
+        /// Zeros will be added to padd existing data to achieve this width, and extra columns will be deleted.
+        /// </summary>
         public void SetFixedWidth(int width)
         {
             fixedWidth = width;
@@ -214,11 +362,21 @@ namespace Spectrogram
             }
         }
 
+        /// <summary>
+        /// Get a vertical image containing ticks and tick labels for the frequency axis.
+        /// </summary>
+        /// <param name="width">size (pixels)</param>
+        /// <param name="offsetHz">number to add to each tick label</param>
+        /// <param name="tickSize">length of each tick mark (pixels)</param>
+        /// <param name="reduction">bin size for vertical data reduction</param>
         public Bitmap GetVerticalScale(int width, int offsetHz = 0, int tickSize = 3, int reduction = 1)
         {
             return Scale.Vertical(width, settings, offsetHz, tickSize, reduction);
         }
 
+        /// <summary>
+        /// Return the vertical position (pixel units) for the given frequency
+        /// </summary>
         public int PixelY(double frequency, int reduction = 1)
         {
             int pixelsFromZeroHz = (int)(settings.PxPerHz * frequency / reduction);
@@ -227,11 +385,18 @@ namespace Spectrogram
             return pixelRow - 1;
         }
 
+        /// <summary>
+        /// Return a list of the FFTs in memory underlying the spectrogram
+        /// </summary>
         public List<double[]> GetFFTs()
         {
             return ffts;
         }
 
+        /// <summary>
+        /// Return frequency and magnitude of the dominant frequency.
+        /// </summary>
+        /// <param name="latestFft">If true, only the latest FFT will be assessed.</param>
         public (double freqHz, double magRms) GetPeak(bool latestFft = true)
         {
             if (ffts.Count == 0)

--- a/src/Spectrogram/SpectrogramGenerator.cs
+++ b/src/Spectrogram/SpectrogramGenerator.cs
@@ -82,7 +82,7 @@ namespace Spectrogram
         [Obsolete("use the Add() method", true)]
         public void AddScroll(float[] values) { }
 
-        public void Add(double[] audio, bool process = true)
+        public void Add(IEnumerable<double> audio, bool process = true)
         {
             newAudio.AddRange(audio);
             if (process)

--- a/src/Spectrogram/SpectrogramGenerator.cs
+++ b/src/Spectrogram/SpectrogramGenerator.cs
@@ -25,14 +25,16 @@ namespace Spectrogram
 
         private readonly Settings settings;
         private readonly List<double[]> ffts = new List<double[]>();
-        private readonly List<double> newAudio = new List<double>();
+        private readonly List<double> newAudio;
         private Colormap cmap = Colormap.Viridis;
 
         public SpectrogramGenerator(int sampleRate, int fftSize, int stepSize,
             double minFreq = 0, double maxFreq = double.PositiveInfinity,
-            int? fixedWidth = null, int offsetHz = 0)
+            int? fixedWidth = null, int offsetHz = 0, List<double> initialAudioList = null)
         {
             settings = new Settings(sampleRate, fftSize, stepSize, minFreq, maxFreq, offsetHz);
+
+            newAudio = initialAudioList ?? new List<double>();
 
             if (fixedWidth.HasValue)
                 SetFixedWidth(fixedWidth.Value);


### PR DESCRIPTION
Long story short, I am developing a WPF app using this library as a use-and-throw-away spectrogram generator. After noticing an unreasonably high memory usage, 

_EDIT: @shirok1's original comment/PR addressed multiple independent topics and @swharden edited it to add expandable sections and link to individual issue pages._

<details>
<summary>1. Bug: ReadWAV returns wrong sample count (#34)</summary>

### 1. Wrong `sampleCount` expression in `ReadWAV` (readme.md)

```cs
int sampleCount = (int) (afr.Length / afr.WaveFormat.BitsPerSample / 8);
```

![image](https://user-images.githubusercontent.com/12044683/131262688-8f73838c-8ea5-46f4-8cf5-270efc460d8a.png)

I guess this `sampleCount` is an estimation of the final size of the `List<double> audio`. *However*, 253296 is 64 times smaller than 16210944. So the most reasonable explanation is `/8` is a typo of `*8`.

![image](https://user-images.githubusercontent.com/12044683/131262943-0f959c36-8ac1-426a-9c7c-37bd4b6c50fd.png)

This "typo" causes the birth of garbage **twice as large** as the `audio` itself.
</details>

<details>
<summary>2. Feature: SpectrogramGenerator.Add() should accept IEnumerable (#35)</summary>

### 2. An unnecessary type requirement in signature of `sg.Add()`

![image](https://user-images.githubusercontent.com/12044683/131263080-0dab1fab-2926-4505-987b-37077cb98ad5.png)

`List<double>.AddRange` accepts an `IEnumerable<double>` as the parameter. *However*, `sg.Add()` asks for an explicit `double[]`, which means that I can't directly use the `List<double>` but **have to** do a `.ToArray()` first, which obvious will waste the memory **as large** as the `audio` itself.
</details>

<details>
<summary>3. Feature: Support initializing with an existing List<double> (#36)</summary>

### 3. The loss of possibility to **DIRECTLY** use the reference of an *external* `List<double>`

The way you design this generator is for continuous or even real-time spectro drawing. In this case, make `List<double> newAudio` read-only, init as an empty one and `.AddRange()` later is the best solution. However, in my case, I need to use SG to generate the spectro for only once. Which means that as the `Bitmap` is generated, both the `audio` in `ReadWAV` and the `newAudio` in SG will immediately become garbage.

The Solution I come up with is this: An addition **Optional Argument** to init `newAudio`. **It keeps the forward compatibility**, but also *enable* me to *prevent meaningless object creation* (and later *`Grow`* into the same size as `audio`, which is the real problem).
![image](https://user-images.githubusercontent.com/12044683/131264511-b2f65251-08a1-4139-af69-278dfb861bf6.png)
</details>

<details>
<summary>4. Question: How to use the debugger</summary>
P.S. I tried to add a breakpoint directly in the "Definition", but this is shown.

![image](https://user-images.githubusercontent.com/12044683/131264405-98eb3708-fe0b-4723-b98d-594b857fa7c7.png)

Could you tell me the right way to do this?
</details>

Hopefully this PR be merged and a new version of Nuget package be released. May you have a wonderful day!